### PR TITLE
Fix /phpWhois/phpWhois#60 upgrade to latest IdnaConvert

### DIFF
--- a/src/Whois.php
+++ b/src/Whois.php
@@ -75,7 +75,7 @@ class Whois extends WhoisClient
 
         $query = trim($query);
 
-        $idn = new \idna_convert();
+        $idn = new \Mso\IdnaConvert\IdnaConvert();
 
         if ($is_utf) {
             $query = $idn->encode($query);


### PR DESCRIPTION
Fix phpWhois/phpWhois#60 upgrade to latest IdnaConvert

- Used the namespace and correct class now that IdnaConvert
  supports namespaces.